### PR TITLE
Fix parameter retrieval when lock status changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
     rev: 22.10.0
     hooks:
       - id: black
-        language_version: python3.7
 
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1

--- a/linien_influxdb/app.py
+++ b/linien_influxdb/app.py
@@ -70,12 +70,12 @@ def main(config, print_only):
         bucket = config_parser["influx2"]["bucket"]
         measurement = config_parser["influx2"]["measurement"]
     interval = config_parser["linien"].getfloat("interval")
-    parameters = config_parser["linien"].getlist("parameters")
+    requested_parameters = config_parser["linien"].getlist("parameters")
     host = config_parser["linien"]["host"]
     username = config_parser["linien"]["username"]
     password = config_parser["linien"]["password"]
 
-    if len(parameters) == 1 and parameters[0] == "":
+    if len(requested_parameters) == 1 and requested_parameters[0] == "":
         raise ValueError(
             "No parameters requested. Add at least one parameter in the .ini file."
         )
@@ -87,15 +87,15 @@ def main(config, print_only):
             write_api = client.write_api()
             while True:
                 point = Point(measurement)
-                parameters = connection.get_parameters(parameters=parameters)
+                parameters = connection.get_parameters(parameters=requested_parameters)
                 print(parameters)
-                for key, value in parameters.items():
+                for key, value in requested_parameters.items():
                     point.field(key, value)
                 write_api.write(bucket=bucket, record=point)
                 sleep(interval)
     else:
         while True:
-            parameters = connection.get_parameters(parameters=parameters)
+            parameters = connection.get_parameters(parameters=requested_parameters)
             print(parameters)
             sleep(interval)
 

--- a/linien_influxdb/app.py
+++ b/linien_influxdb/app.py
@@ -1,5 +1,6 @@
 from configparser import ConfigParser
 from time import sleep
+from typing import Any, Dict, List
 
 import click
 from influxdb_client import InfluxDBClient, Point
@@ -7,12 +8,12 @@ from linien.client.connection import LinienClient, MHz, Vpp
 
 
 class LinienConnection:
-    def __init__(self, host, username="root", password="root"):
+    def __init__(self, host: str, username: str = "root", password: str = "root"):
         self.client = LinienClient(
             {"host": host, "username": username, "password": password}
         )
 
-    def get_parameters(self, parameters):
+    def get_parameters(self, parameters: List[str]) -> Dict[str, Any]:
 
         # get the `signal_stats` parameter only once and only if required
         stats_suffices = ["_min", "_max", "_mean", "_std"]
@@ -59,7 +60,7 @@ class LinienConnection:
     is_flag=True,
     help="Do not write the logged data to influxdb.",
 )
-def main(config, print_only):
+def main(config: str, print_only: bool):
     """Logs Linien parameters according to the configuration in CONFIG ini file."""
     config_parser = ConfigParser(
         converters={"list": lambda x: [i.strip() for i in x.split(",")]}


### PR DESCRIPTION
Problem was overwriting of `parameters` in the `while` loops.

Adding some type hints so things like that could be spotted more easily.

Fixes #18.